### PR TITLE
Add related posts section

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,93 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { LOCALE } from '@config';
+
+export interface Props {
+  currentSlug: string;
+  currentTags: string[];
+  posts: CollectionEntry<'blog'>[];
+}
+
+const { currentSlug, currentTags = [], posts = [] } = Astro.props;
+
+const cutoff = new Date();
+cutoff.setFullYear(cutoff.getFullYear() - 1);
+
+const tagSet = new Set(
+  currentTags.map(tag => String(tag).toLowerCase().trim()).filter(Boolean)
+);
+
+const formatter = new Intl.DateTimeFormat(LOCALE.langTag, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+});
+
+const relatedPool = posts.filter(({ slug, data }) => {
+  if (!data || slug === currentSlug) return false;
+  if (data.draft) return false;
+
+  const published = new Date(data.pubDatetime);
+  if (Number.isNaN(published.getTime())) return false;
+  if (published < cutoff) return false;
+
+  const postTags = (data.tags ?? [])
+    .map(tag => String(tag).toLowerCase().trim())
+    .filter(Boolean);
+
+  return postTags.some(tag => tagSet.has(tag));
+});
+
+// Shuffle to allow random ordering within the recent pool
+for (let i = relatedPool.length - 1; i > 0; i--) {
+  const j = Math.floor(Math.random() * (i + 1));
+  [relatedPool[i], relatedPool[j]] = [relatedPool[j], relatedPool[i]];
+}
+
+const relatedPosts = relatedPool.slice(0, 3);
+---
+
+{relatedPosts.length > 0 && (
+  <section class="related-posts" aria-labelledby="related-posts-title">
+    <h2 id="related-posts-title" class="related-title" data-no-anchor="true">
+      Related posts
+    </h2>
+    <ul>
+      {relatedPosts.map(({ slug, data }) => {
+        const published = new Date(data.pubDatetime);
+        return (
+          <li>
+            <a href={`/blog/${slug}/`}>{data.title}</a>
+            <span class="related-date">{formatter.format(published)}</span>
+          </li>
+        );
+      })}
+    </ul>
+  </section>
+)}
+
+<style>
+  .related-posts {
+    @apply mt-10 border-t border-skin-line pt-6;
+  }
+
+  .related-title {
+    @apply mb-4 text-xl font-semibold italic text-skin-base;
+  }
+
+  .related-posts ul {
+    @apply flex flex-col gap-3;
+  }
+
+  .related-posts li {
+    @apply flex items-baseline justify-between gap-3;
+  }
+
+  .related-posts a {
+    @apply font-medium text-skin-accent hover:underline;
+  }
+
+  .related-date {
+    @apply whitespace-nowrap text-xs text-skin-base/70;
+  }
+</style>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -9,6 +9,7 @@ import type { CollectionEntry } from 'astro:content';
 import { slugifyStr } from '@utils/slugify';
 import ShareLinks from '@components/ShareLinks.astro';
 import SupportButton from '@components/SupportButton.astro';
+import RelatedPosts from '@components/RelatedPosts.astro';
 import { SITE } from '@config';
 import IconCopy from '@assets/icons/IconCopy.svg?raw';
 import IconCheck from '@assets/icons/IconCheck.svg?raw';
@@ -102,6 +103,8 @@ const nextPost =
     <article id="article" role="article" class="prose mx-auto mt-8 max-w-3xl">
       <Content />
     </article>
+
+    <RelatedPosts currentSlug={post.slug} currentTags={tags} posts={posts} />
 
     <div class="support-share-row">
       <ShareLinks />
@@ -266,6 +269,9 @@ const nextPost =
           document.querySelectorAll('h2, h3, h4, h5, h6')
         );
         for (let heading of headings) {
+          if (heading.dataset?.noAnchor === 'true' || heading.classList.contains('no-anchor')) {
+            continue;
+          }
           heading.classList.add('group');
           let link = document.createElement('a');
           link.innerText = '#';


### PR DESCRIPTION
This pull request introduces a new "Related Posts" feature to blog post pages, surfacing up to three recent, tag-matching posts at the end of each article. The implementation includes a dedicated component for selecting and displaying related posts, updates to the post layout to render this component, and a small fix to prevent anchor links from appearing on specific headings.

**New Related Posts Feature:**

* Added a new `RelatedPosts.astro` component that:
  - Filters posts by shared tags with the current post, excludes drafts and the current post itself, and only considers posts from the last year.
  - Randomizes the order and displays up to three related posts, including their titles and publication dates.
* Integrated the `RelatedPosts` component into the post details layout, passing the current post's slug, tags, and the list of all posts as props. [[1]](diffhunk://#diff-a715a222a25309a700bbd78da2487a26184df587fd72b12ddc8fe3dd6b89ceadR12) [[2]](diffhunk://#diff-a715a222a25309a700bbd78da2487a26184df587fd72b12ddc8fe3dd6b89ceadR107-R108)

**UI/UX Improvements:**

* Updated the heading anchor logic to skip headings marked with `data-no-anchor="true"` or the `no-anchor` class, preventing unwanted anchor links on elements like the "Related posts" section heading.